### PR TITLE
Add app icon (favicon) for Next.js application

### DIFF
--- a/next-app/app/icon.svg
+++ b/next-app/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="8" fill="#D0643A"/>
+  <text x="16" y="22" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="18" fill="#FFFFFF" letter-spacing="-0.5">DB</text>
+</svg>


### PR DESCRIPTION
## Summary
Added an SVG icon file to serve as the favicon for the Next.js application.

## Changes
- Created `next-app/app/icon.svg` with a custom app icon featuring:
  - Rounded square background with a rust/orange color (#D0643A)
  - White "DB" text centered on the icon
  - 32x32px dimensions suitable for favicon usage

## Implementation Details
The icon uses a simple SVG design with a rounded rectangle background (8px border radius) and Georgia serif font for the "DB" initials. This file will be automatically picked up by Next.js as the app's favicon when placed in the app directory.

https://claude.ai/code/session_01FPWyYzz92NaskPxvCBdohN